### PR TITLE
Fix: References after move to @ergebnis

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1851,7 +1851,7 @@
                     "homepage": "http://blog.astrumfutura.com"
                 },
                 {
-                    "name": "Théo FIDRY",
+                    "name": "Théo Fidry",
                     "email": "theo.fidry@gmail.com"
                 }
             ],
@@ -1905,7 +1905,7 @@
             ],
             "authors": [
                 {
-                    "name": "Padraic Brady",
+                    "name": "Pádraic Brady",
                     "email": "padraic.brady@gmail.com",
                     "homepage": "http://blog.astrumfutura.com"
                 }


### PR DESCRIPTION
This PR

* [x] fixes references after the move from @localheinz to @ergebnis