### PR TITLE
Fix: Rename namespace after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-printer
+ * @see https://github.com/ergebnis/json-printer
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2018 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/json-printer
+@see https://github.com/ergebnis/json-printer
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header), [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`2.0.1...master`][2.0.1...master].
 
+### Changed
+
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#67]), by [@localheinz]
+
 ### Fixed
 
 * Removed support for PHP 7.1 ([#55]), by [@localheinz]
 * Required implicit dependencies `ext-json` and `ext-mbstring` explicitly ([#63]), by [@localheinz]
 
-[2.0.1...master]: https://github.com/localheinz/json-printer/compare/2.0.1...master
+[2.0.1...master]: https://github.com/ergebnis/json-printer/compare/2.0.1...master
 
-[#55]: https://github.com/localheinz/json-printer/pull/55
-[#63]: https://github.com/localheinz/json-printer/pull/63
+[#55]: https://github.com/ergebnis/json-printer/pull/55
+[#63]: https://github.com/ergebnis/json-printer/pull/63
+[#67]: https://github.com/ergebnis/json-printer/pull/67
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # json-printer
 
-[![Continuous Integration](https://github.com/localheinz/json-printer/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/json-printer/actions)
-[![Code Coverage](https://codecov.io/gh/localheinz/json-printer/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/json-printer)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/json-printer/v/stable)](https://packagist.org/packages/localheinz/json-printer)
-[![Total Downloads](https://poser.pugx.org/localheinz/json-printer/downloads)](https://packagist.org/packages/localheinz/json-printer)
+[![Continuous Integration](https://github.com/ergebnis/json-printer/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/json-printer/actions)
+[![Code Coverage](https://codecov.io/gh/ergebnis/json-printer/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/json-printer)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/json-printer/v/stable)](https://packagist.org/packages/ergebnis/json-printer)
+[![Total Downloads](https://poser.pugx.org/ergebnis/json-printer/downloads)](https://packagist.org/packages/ergebnis/json-printer)
 
 Provides a JSON printer, allowing for flexible indentation.
 
@@ -12,7 +12,7 @@ Provides a JSON printer, allowing for flexible indentation.
 Run
 
 ```
-$ composer require localheinz/json-printer
+$ composer require ergebnis/json-printer
 ```
 
 ## Usage
@@ -39,10 +39,10 @@ or indented with 4 spaces:
 
 but we want to indent it with 2 spaces (or tabs).
 
-This is where `Localheinz\Json\Printer\Printer` comes in
+This is where `Ergebnis\Json\Printer\Printer` comes in
 
 ```php
-use Localheinz\Json\Printer\Printer;
+use Ergebnis\Json\Printer\Printer;
 
 $printer = new Printer();
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "localheinz/json-printer",
+  "name": "ergebnis/json-printer",
   "type": "library",
   "description": "Provides a JSON printer, allowing for flexible indentation.",
   "keywords": [
@@ -7,7 +7,7 @@
     "printer",
     "formatter"
   ],
-  "homepage": "https://github.com/localheinz/json-printer",
+  "homepage": "https://github.com/ergebnis/json-printer",
   "license": "MIT",
   "authors": [
     {
@@ -19,6 +19,9 @@
     "php": "^7.2",
     "ext-json": "*",
     "ext-mbstring": "*"
+  },
+  "replace": {
+    "localheinz/json-printer": "*"
   },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
@@ -38,16 +41,16 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\Json\\Printer\\": "src/"
+      "Ergebnis\\Json\\Printer\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\Json\\Printer\\Test\\": "test/"
+      "Ergebnis\\Json\\Printer\\Test\\": "test/"
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/json-printer/issues",
-    "source": "https://github.com/localheinz/json-printer"
+    "issues": "https://github.com/ergebnis/json-printer/issues",
+    "source": "https://github.com/ergebnis/json-printer"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d667fe66563cf711bf98e582a276a78",
+    "content-hash": "83c96d6b36b53d293ab531f19067eb36",
     "packages": [],
     "packages-dev": [
         {

--- a/src/Printer.php
+++ b/src/Printer.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-printer
+ * @see https://github.com/ergebnis/json-printer
  */
 
-namespace Localheinz\Json\Printer;
+namespace Ergebnis\Json\Printer;
 
 final class Printer implements PrinterInterface
 {

--- a/src/PrinterInterface.php
+++ b/src/PrinterInterface.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-printer
+ * @see https://github.com/ergebnis/json-printer
  */
 
-namespace Localheinz\Json\Printer;
+namespace Ergebnis\Json\Printer;
 
 interface PrinterInterface
 {

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-printer
+ * @see https://github.com/ergebnis/json-printer
  */
 
-namespace Localheinz\Json\Printer\Test\AutoReview;
+namespace Ergebnis\Json\Printer\Test\AutoReview;
 
 use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
@@ -29,8 +29,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\Json\\Printer\\',
-            'Localheinz\\Json\\Printer\\Test\\Unit\\'
+            'Ergebnis\\Json\\Printer\\',
+            'Ergebnis\\Json\\Printer\\Test\\Unit\\'
         );
     }
 }

--- a/test/Bench/PrinterBench.php
+++ b/test/Bench/PrinterBench.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-printer
+ * @see https://github.com/ergebnis/json-printer
  */
 
-namespace Localheinz\Json\Printer\Test\Bench;
+namespace Ergebnis\Json\Printer\Test\Bench;
 
-use Localheinz\Json\Printer\Printer;
+use Ergebnis\Json\Printer\Printer;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 
 final class PrinterBench

--- a/test/Unit/PrinterTest.php
+++ b/test/Unit/PrinterTest.php
@@ -8,20 +8,20 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/json-printer
+ * @see https://github.com/ergebnis/json-printer
  */
 
-namespace Localheinz\Json\Printer\Test\Unit;
+namespace Ergebnis\Json\Printer\Test\Unit;
 
+use Ergebnis\Json\Printer\Printer;
+use Ergebnis\Json\Printer\PrinterInterface;
 use Ergebnis\Test\Util\Helper;
-use Localheinz\Json\Printer\Printer;
-use Localheinz\Json\Printer\PrinterInterface;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Json\Printer\Printer
+ * @covers \Ergebnis\Json\Printer\Printer
  */
 final class PrinterTest extends Framework\TestCase
 {
@@ -367,8 +367,8 @@ JSON;
         $json = <<<'JSON'
 {
             "foo":          {
-    
-    
+
+
 }   ,
     "bar": [                                ]
         }


### PR DESCRIPTION
This PR

* [x] renames the vendor namespace `Localheinz` to `Ergebnis` after the move to @ergebnis