### PR TITLE
Fix: Remove inappropriate replace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.0.1...master`][3.0.0...master].
+For a full diff see [`3.0.1...master`][3.0.1...master].
+
+## [`3.0.1`][3.0.1]
+
+For a full diff see [`3.0.0...3.0.1`][3.0.0...3.0.1].
+
+### Fixed
+
+* Removed an inappropriate `replace` configuration from `composer.json` ([#72]), by [@localheinz]
 
 ## [`3.0.0`][3.0.0]
 
@@ -80,19 +88,22 @@ For a full diff see [`8849fc6...1.0.0`][8849fc6...1.0.0].
 [2.0.0]: https://github.com/ergebnis/json-printer/releases/tag/2.0.0
 [2.0.1]: https://github.com/ergebnis/json-printer/releases/tag/2.0.1
 [3.0.0]: https://github.com/ergebnis/json-printer/releases/tag/3.0.0
+[3.0.1]: https://github.com/ergebnis/json-printer/releases/tag/3.0.1
 
 [8849fc6...1.0.0]: https://github.com/ergebnis/json-printer/compare/8849fc6...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/json-printer/compare/1.0.0...1.1.0
 [1.1.0...2.0.0]: https://github.com/ergebnis/json-printer/compare/1.1.0...2.0.0
 [2.0.0...2.0.1]: https://github.com/ergebnis/json-printer/compare/2.0.0...2.0.1
 [2.0.1...3.0.0]: https://github.com/ergebnis/json-printer/compare/2.0.1...3.0.0
-[3.0.0...master]: https://github.com/ergebnis/json-printer/compare/3.0.0...master
+[3.0.0...3.0.1]: https://github.com/ergebnis/json-printer/compare/3.0.0...3.0.1
+[3.0.1...master]: https://github.com/ergebnis/json-printer/compare/3.0.1...master
 
 [#33]: https://github.com/ergebnis/json-printer/pull/33
 [#37]: https://github.com/ergebnis/json-printer/pull/37
 [#55]: https://github.com/ergebnis/json-printer/pull/55
 [#63]: https://github.com/ergebnis/json-printer/pull/63
 [#67]: https://github.com/ergebnis/json-printer/pull/67
+[#72]: https://github.com/ergebnis/json-printer/pull/72
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,6 @@
     "ext-json": "*",
     "ext-mbstring": "*"
   },
-  "replace": {
-    "localheinz/json-printer": "*"
-  },
   "require-dev": {
     "ergebnis/php-cs-fixer-config": "~1.1.0",
     "ergebnis/phpstan-rules": "~0.14.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "485e37b964435c5ddf1436b27d505002",
+    "content-hash": "b8e2317b3e6fdb928bf8d7d771878bec",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
This PR

* [x] removes an inappropriate `replace` configuration from `composer.json`

Follows #67.