### PR TITLE
Fix: Remove wrapping from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ which results in `$printed`:
 }
 ```
 
-:bulb: Note that this printer is only concerned with normalizing the
-indentation, no escaping or un-escaping occurs.
+:bulb: Note that this printer is only concerned with normalizing the indentation, no escaping or un-escaping occurs.
 
 ## Changelog
 
@@ -89,16 +88,6 @@ This package is licensed using the MIT License.
 
 ## Credits
 
-The [`Printer`](src/Printer.php) is adopted from
-[`Composer\Json\JsonFormatter`](https://github.com/composer/composer/blob/1.6.0/src/Composer/Json/JsonFormatter.php)
-(originally licensed under MIT by [Nils Adermann](https://github.com/naderman)
-and [Jordi Boggiano](https://github.com/seldaek)), who adopted it from a
-[blog post by Dave Perrett](https://www.daveperrett.com/articles/2008/03/11/format-json-with-php/)
-(originally licensed under MIT by [Dave Perrett](https://github.com/recurser)).
+The [`Printer`](src/Printer.php) is adopted from [`Composer\Json\JsonFormatter`](https://github.com/composer/composer/blob/1.6.0/src/Composer/Json/JsonFormatter.php) (originally licensed under MIT by [Nils Adermann](https://github.com/naderman) and [Jordi Boggiano](https://github.com/seldaek)), who adopted it from a [blog post by Dave Perrett](https://www.daveperrett.com/articles/2008/03/11/format-json-with-php/) (originally licensed under MIT by [Dave Perrett](https://github.com/recurser)).
 
-The [`PrinterTest`](test/Unit/PrinterTest.php) is inspired
-by [`Composer\Test\Json\JsonFormatterTest`](https://github.com/composer/composer/blob/1.6.0/tests/Composer/Test/Json/JsonFormatterTest.php)
-(originally licensed under MIT by [Nils Adermann](https://github.com/naderman)
-and [Jordi Boggiano](https://github.com/seldaek)), as well as
-[`ZendTest\Json\JsonTest`](https://github.com/zendframework/zend-json/blob/release-3.0.0/test/JsonTest.php)
-(originally licensed under New BSD License).
+The [`PrinterTest`](test/Unit/PrinterTest.php) is inspired by [`Composer\Test\Json\JsonFormatterTest`](https://github.com/composer/composer/blob/1.6.0/tests/Composer/Test/Json/JsonFormatterTest.php) (originally licensed under MIT by [Nils Adermann](https://github.com/naderman) and [Jordi Boggiano](https://github.com/seldaek)), as well as [`ZendTest\Json\JsonTest`](https://github.com/zendframework/zend-json/blob/release-3.0.0/test/JsonTest.php) (originally licensed under New BSD License).


### PR DESCRIPTION
This PR

* [x] removes the wrapping from `README.md`