### PR TITLE
Fix: Use main as default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 # https://github.com/probot/settings
 
 branches:
-  - name: "master"
+  - name: "main"
 
     # https://developer.github.com/v3/repos/branches/#remove-branch-protection
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -83,7 +83,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   archived: false
-  default_branch: "master"
+  default_branch: "main"
   delete_branch_on_merge: true
   description: ":page_with_curl: Provides a JSON printer, allowing for flexible indentation."
   has_downloads: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - "master"
+      - "main"
 
 env:
   MIN_COVERED_MSI: 92

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`3.0.2...master`][3.0.2...master].
+For a full diff see [`3.0.2...main`][3.0.2...main].
 
 ## [`3.0.2`][3.0.2]
 
@@ -106,7 +106,7 @@ For a full diff see [`8849fc6...1.0.0`][8849fc6...1.0.0].
 [2.0.1...3.0.0]: https://github.com/ergebnis/json-printer/compare/2.0.1...3.0.0
 [3.0.0...3.0.1]: https://github.com/ergebnis/json-printer/compare/3.0.0...3.0.1
 [3.0.1...3.0.2]: https://github.com/ergebnis/json-printer/compare/3.0.1...3.0.2
-[3.0.2...master]: https://github.com/ergebnis/json-printer/compare/3.0.2...master
+[3.0.2...main]: https://github.com/ergebnis/json-printer/compare/3.0.2...main
 
 [#33]: https://github.com/ergebnis/json-printer/pull/33
 [#37]: https://github.com/ergebnis/json-printer/pull/37

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # json-printer
 
-[![Integrate](https://github.com/ergebnis/json-printer/workflows/Integrate/badge.svg?branch=master)](https://github.com/ergebnis/json-printer/actions)
-[![Prune](https://github.com/ergebnis/json-printer/workflows/Prune/badge.svg?branch=master)](https://github.com/ergebnis/json-printer/actions)
-[![Release](https://github.com/ergebnis/json-printer/workflows/Release/badge.svg?branch=master)](https://github.com/ergebnis/json-printer/actions)
-[![Renew](https://github.com/ergebnis/json-printer/workflows/Renew/badge.svg?branch=master)](https://github.com/ergebnis/json-printer/actions)
+[![Integrate](https://github.com/ergebnis/json-printer/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/json-printer/actions)
+[![Prune](https://github.com/ergebnis/json-printer/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/json-printer/actions)
+[![Release](https://github.com/ergebnis/json-printer/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/json-printer/actions)
+[![Renew](https://github.com/ergebnis/json-printer/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/json-printer/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/json-printer/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/json-printer)
+[![Code Coverage](https://codecov.io/gh/ergebnis/json-printer/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/json-printer)
 [![Type Coverage](https://shepherd.dev/github/ergebnis/json-printer/coverage.svg)](https://shepherd.dev/github/ergebnis/json-printer)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/json-printer/v/stable)](https://packagist.org/packages/ergebnis/json-printer)
@@ -84,7 +84,7 @@ Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## Code of Conduct
 
-Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/master/CODE_OF_CONDUCT.md).
+Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
This PR

* [x] uses `main` as default branch name

✊🏿 Black lives matter.