### PR TITLE
Fix: Require tests on PHP 8.0 to pass

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -31,6 +31,9 @@ branches:
           - "Tests (7.4, highest)"
           - "Tests (7.4, locked)"
           - "Tests (7.4, lowest)"
+          - "Tests (8.0, highest)"
+          - "Tests (8.0, locked)"
+          - "Tests (8.0, lowest)"
         strict: false
       restrictions:
 


### PR DESCRIPTION
This PR

* [x] requires tests on PHP 8.0 to pass

Follows #172.