### PR TITLE
Fix: Drop support for PHP 7.1

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,13 +15,10 @@ branches:
       required_status_checks:
         contexts:
           - "Code Coverage (7.4, locked)"
-          - "Coding Standards (7.1, locked)"
+          - "Coding Standards (7.2, locked)"
           - "Dependency Analysis (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (7.4, locked)"
-          - "Tests (7.1, highest)"
-          - "Tests (7.1, locked)"
-          - "Tests (7.1, lowest)"
           - "Tests (7.2, highest)"
           - "Tests (7.2, locked)"
           - "Tests (7.2, lowest)"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"
@@ -218,7 +218,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`3.1.0...main`][3.1.0...main].
+For a full diff see [`3.1.1...main`][3.1.1...main].
+
+## [`3.1.1`][3.1.1]
+
+For a full diff see [`3.1.0...3.1.1`][3.1.0...3.1.1].
+
+### Changed
+
+* Dropped support for PHP 7.1 ([#199]), by [@localheinz]
 
 ## [`3.1.0`][3.1.0]
 
@@ -107,6 +115,7 @@ For a full diff see [`8849fc6...1.0.0`][8849fc6...1.0.0].
 [3.0.1]: https://github.com/ergebnis/json-printer/releases/tag/3.0.1
 [3.0.2]: https://github.com/ergebnis/json-printer/releases/tag/3.0.2
 [3.1.0]: https://github.com/ergebnis/json-printer/releases/tag/3.1.0
+[3.1.1]: https://github.com/ergebnis/json-printer/releases/tag/3.1.1
 
 [8849fc6...1.0.0]: https://github.com/ergebnis/json-printer/compare/8849fc6...1.0.0
 [1.0.0...1.1.0]: https://github.com/ergebnis/json-printer/compare/1.0.0...1.1.0
@@ -116,7 +125,8 @@ For a full diff see [`8849fc6...1.0.0`][8849fc6...1.0.0].
 [3.0.0...3.0.1]: https://github.com/ergebnis/json-printer/compare/3.0.0...3.0.1
 [3.0.1...3.0.2]: https://github.com/ergebnis/json-printer/compare/3.0.1...3.0.2
 [3.0.2...3.1.0]: https://github.com/ergebnis/json-printer/compare/3.0.2...3.1.0
-[3.1.0...main]: https://github.com/ergebnis/json-printer/compare/3.1.0...main
+[3.1.0...3.1.1]: https://github.com/ergebnis/json-printer/compare/3.1.0...3.1.1
+[3.1.1...main]: https://github.com/ergebnis/json-printer/compare/3.1.1...main
 
 [#33]: https://github.com/ergebnis/json-printer/pull/33
 [#37]: https://github.com/ergebnis/json-printer/pull/37
@@ -126,6 +136,7 @@ For a full diff see [`8849fc6...1.0.0`][8849fc6...1.0.0].
 [#72]: https://github.com/ergebnis/json-printer/pull/72
 [#76]: https://github.com/ergebnis/json-printer/pull/77
 [#172]: https://github.com/ergebnis/json-printer/pull/172
+[#199]: https://github.com/ergebnis/json-printer/pull/199
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^7.1 || ^8.0",
+    "php": "^7.2 || ^8.0",
     "ext-json": "*",
     "ext-mbstring": "*"
   },
@@ -37,7 +37,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.1.33"
+      "php": "7.2.33"
     },
     "preferred-install": "dist",
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff0a3916af90719b03e35abe9b1c7d35",
+    "content-hash": "9f8487d0a495bd06c898cfc886c05508",
     "packages": [],
     "packages-dev": [
         {
@@ -2161,6 +2161,7 @@
                 "self-update",
                 "update"
             ],
+            "abandoned": true,
             "time": "2018-03-30T12:52:15+00:00"
         },
         {
@@ -3128,6 +3129,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {
@@ -5390,13 +5392,13 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "ext-mbstring": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.33"
+        "php": "7.2.33"
     },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.1

Related to https://github.com/ergebnis/composer-normalize/issues/529.