### PR TITLE
Fix: Do not use deprecated `--diff-format` option

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -77,7 +77,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-php-cs-fixer-"
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --diff-format=udiff --dry-run --verbose"
+        run: "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --dry-run --verbose"
 
   dependency-analysis:
     name: "Dependency Analysis"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -65,7 +65,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-php-cs-fixer-"
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --diff-format=udiff --verbose"
+        run: "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --verbose"
 
       - name: "Commit modified files"
         uses: "stefanzweifel/git-auto-commit-action@v4.12.0"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ coding-standards: vendor ## Normalizes composer.json with ergebnis/composer-norm
 	.phive/composer-normalize
 	yamllint -c .yamllint.yaml --strict .
 	mkdir -p .build/php-cs-fixer
-	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --diff-format=udiff --verbose
+	vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --diff --verbose
 
 .PHONY: dependency-analysis
 dependency-analysis: vendor ## Runs a dependency analysis with maglnet/composer-require-checker


### PR DESCRIPTION
This pull request

- [x] stops using the deprecated `--diff-format` option when running `friendsofphp/php-cs-fixer`